### PR TITLE
Removes trailing comma from Watchdog sample which was causing error

### DIFF
--- a/drupal.json
+++ b/drupal.json
@@ -62,7 +62,7 @@
     },
     "sample": [
       { "line": "Oct  9 06:27:30 test-server test.local: http://test.local|1475994450|page not found|2.2.2.2|http://test.local/www.googletagmanager.com/ns.html?id=GTM-WJW75D||0||www.googletagmanager.com/ns.html request_id=\"v-7461a700-8de9-11e6-aaae-12ab7d2b3029\"" },
-      { "line": "Oct  9 06:28:51 test-server test.local: https://test.local|1475994531|php|2.2.2.2|https://test.local/user/register|https://test.local/|0||Warning: Creating default object from empty value in test_preprocess_page() (line 241 of /mnt/www/html/test/docroot/sites/all/themes/test/template.php). request_id=\"77ad1e45-0f38-4fd8-816f-4c77d9f870ae\"" },
+      { "line": "Oct  9 06:28:51 test-server test.local: https://test.local|1475994531|php|2.2.2.2|https://test.local/user/register|https://test.local/|0||Warning: Creating default object from empty value in test_preprocess_page() (line 241 of /mnt/www/html/test/docroot/sites/all/themes/test/template.php). request_id=\"77ad1e45-0f38-4fd8-816f-4c77d9f870ae\"" }
     ]
   }
 }


### PR DESCRIPTION
I'm no json parser, but lnav cried and complained at launch:
`lnav /tmp/ihtPhantom.log 
/Users/bronius/.lnav//formats/nicks_drupal/drupal.json: invalid json -- parse error: unallowed token at this point in JSON text
          -816f-4c77d9f870ae\"" },     ]   } } 
                     (right here) ------^`
ok that was that.. removed the comman, et voila, launches just fine again